### PR TITLE
Drop Feed

### DIFF
--- a/accounts/abi/bind/backends/dropped_tx_subscription.go
+++ b/accounts/abi/bind/backends/dropped_tx_subscription.go
@@ -1,0 +1,10 @@
+package backends
+
+import (
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+func (fb *filterBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription {
+	return nullSubscription()
+}

--- a/core/events.go
+++ b/core/events.go
@@ -26,8 +26,9 @@ type NewTxsEvent struct{ Txs []*types.Transaction }
 
 // DropTxsEvent is posted when a batch of transactions are removed from the transaction pool
 type DropTxsEvent struct {
-	Txs    []*types.Transaction
-	Reason string
+	Txs         []*types.Transaction
+	Reason      string
+	Replacement *types.Transaction
 }
 
 // NewMinedBlockEvent is posted when a block has been imported.

--- a/core/events.go
+++ b/core/events.go
@@ -24,6 +24,12 @@ import (
 // NewTxsEvent is posted when a batch of transactions enter the transaction pool.
 type NewTxsEvent struct{ Txs []*types.Transaction }
 
+// DropTxsEvent is posted when a batch of transactions are removed from the transaction pool
+type DropTxsEvent struct {
+	Txs    []*types.Transaction
+	Reason string
+}
+
 // NewMinedBlockEvent is posted when a block has been imported.
 type NewMinedBlockEvent struct{ Block *types.Block }
 
@@ -41,3 +47,16 @@ type ChainSideEvent struct {
 }
 
 type ChainHeadEvent struct{ Block *types.Block }
+
+const (
+	dropUnderpriced = "underpriced-txs"
+	dropLowNonce    = "low-nonce-txs"
+	dropUnpayable   = "unpayable-txs"
+
+	dropAccountCap      = "account-cap-txs" // Accounts exceeding txpool.accountslots transactions
+	dropReplaced        = "replaced-txs"
+	dropUnexecutable    = "unexecutable-txs"
+	dropTruncating      = "truncating-txs"
+	dropOld             = "old-txs"
+	dropGasPriceUpdated = "updated-gas-price"
+)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -736,8 +736,9 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			pool.priced.Removed(1)
 			pendingReplaceMeter.Mark(1)
 			pool.dropTxFeed.Send(DropTxsEvent{
-				Txs:    []*types.Transaction{old},
-				Reason: dropReplaced,
+				Txs:         []*types.Transaction{old},
+				Reason:      dropReplaced,
+				Replacement: tx,
 			})
 		}
 		pool.all.Add(tx, isLocal)

--- a/eth/dropped_tx_subscription.go
+++ b/eth/dropped_tx_subscription.go
@@ -1,0 +1,17 @@
+// This file extends the EthAPIBackend with functions for BlockNative's dropped
+// transaction feeds.
+//
+// As this is part of a fork, and not included in core geth, keeping it in a
+// separate file helps protect against potential merge conflicts. If this were
+// ever to be merged into core geth, it should be relocated to ./api_backend.go
+
+package eth
+
+import (
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+func (b *EthAPIBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription {
+	return b.eth.TxPool().SubscribeDropTxsEvent(ch)
+}

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -2,21 +2,72 @@ package filters
 
 import (
 	"context"
+	"time"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
 type dropNotification struct {
-	TxHash common.Hash `json:"txhash"`
-	Reason string      `json:"reason"`
+	// TxHash common.Hash `json:"txhash"`
+	Tx          *ethapi.RPCTransaction `json:"tx"`
+	Reason      string                 `json:"reason"`
+	Replacement *ethapi.RPCTransaction `json:"replacedby,omitempty"`
+	Peer        interface{}            `json:"peer,omitempty"`
+	Time        int64                  `json:"ts"`
 }
 
 type rejectNotification struct {
 	Tx     *types.Transaction
 	Reason string `json:"reason"`
+}
+
+// newRPCTransaction returns a transaction that will serialize to the RPC
+// representation, with the given location metadata set (if available).
+func newRPCPendingTransaction(tx *types.Transaction) *ethapi.RPCTransaction {
+	if tx == nil {
+		return nil
+	}
+	var signer types.Signer
+	if tx.Protected() {
+		signer = types.LatestSignerForChainID(tx.ChainId())
+	} else {
+		signer = types.HomesteadSigner{}
+	}
+	from, _ := types.Sender(signer, tx)
+	v, r, s := tx.RawSignatureValues()
+	result := &ethapi.RPCTransaction{
+		Type:     hexutil.Uint64(tx.Type()),
+		From:     from,
+		Gas:      hexutil.Uint64(tx.Gas()),
+		GasPrice: (*hexutil.Big)(tx.GasPrice()),
+		Hash:     tx.Hash(),
+		Input:    hexutil.Bytes(tx.Data()),
+		Nonce:    hexutil.Uint64(tx.Nonce()),
+		To:       tx.To(),
+		Value:    (*hexutil.Big)(tx.Value()),
+		V:        (*hexutil.Big)(v),
+		R:        (*hexutil.Big)(r),
+		S:        (*hexutil.Big)(s),
+	}
+	switch tx.Type() {
+	case types.AccessListTxType:
+		al := tx.AccessList()
+		result.Accesses = &al
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+	case types.DynamicFeeTxType:
+		al := tx.AccessList()
+		result.Accesses = &al
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
+		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
+		// if the transaction has been mined, compute the effective gas price
+		result.GasPrice = nil
+	}
+	return result
 }
 
 // DroppedTransactions send a notification each time a transaction is dropped from the mempool
@@ -36,7 +87,12 @@ func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subsc
 			select {
 			case d := <-dropped:
 				for _, tx := range d.Txs {
-					notifier.Notify(rpcSub.ID, &dropNotification{TxHash: tx.Hash(), Reason: d.Reason})
+					notification := &dropNotification{
+						Tx:     newRPCPendingTransaction(tx),
+						Reason: d.Reason,
+						Time:   time.Now().UnixNano(),
+					}
+					notifier.Notify(rpcSub.ID, notification)
 				}
 			case <-rpcSub.Err():
 				droppedSub.Unsubscribe()

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -88,9 +88,10 @@ func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subsc
 			case d := <-dropped:
 				for _, tx := range d.Txs {
 					notification := &dropNotification{
-						Tx:     newRPCPendingTransaction(tx),
-						Reason: d.Reason,
-						Time:   time.Now().UnixNano(),
+						Tx:          newRPCPendingTransaction(tx),
+						Reason:      d.Reason,
+						Replacement: newRPCPendingTransaction(d.Replacement),
+						Time:        time.Now().UnixNano(),
 					}
 					notifier.Notify(rpcSub.ID, notification)
 				}

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -1,0 +1,52 @@
+package filters
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type dropNotification struct {
+	TxHash common.Hash `json:"txhash"`
+	Reason string      `json:"reason"`
+}
+
+type rejectNotification struct {
+	Tx     *types.Transaction
+	Reason string `json:"reason"`
+}
+
+// DroppedTransactions send a notification each time a transaction is dropped from the mempool
+func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		dropped := make(chan core.DropTxsEvent)
+		droppedSub := api.backend.SubscribeDropTxsEvent(dropped)
+
+		for {
+			select {
+			case d := <-dropped:
+				for _, tx := range d.Txs {
+					notifier.Notify(rpcSub.ID, &dropNotification{TxHash: tx.Hash(), Reason: d.Reason})
+				}
+			case <-rpcSub.Err():
+				droppedSub.Unsubscribe()
+				return
+			case <-notifier.Closed():
+				droppedSub.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -40,6 +40,7 @@ type Backend interface {
 	GetBorBlockLogs(ctx context.Context, blockHash common.Hash) ([]*types.Log, error)
 
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+	SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -79,6 +79,7 @@ type Backend interface {
 	TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+	SubscribeDropTxsEvent(chan<- core.DropTxsEvent) event.Subscription
 
 	// Filter API
 	BloomStatus() (uint64, uint64)

--- a/les/dropped_tx_subscription.go
+++ b/les/dropped_tx_subscription.go
@@ -1,0 +1,28 @@
+// This file extends the LesApiBackend with functions for BlockNative's dropped
+// transaction feeds.
+//
+// As this is part of a fork, and not included in core geth, keeping it in a
+// separate file helps protect against potential merge conflicts. If this were
+// ever to be merged into core geth, it should be relocated to ./api_backend.go
+
+package les
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+type unimplementedSubscription struct{}
+
+func (s *unimplementedSubscription) Unsubscribe() {}
+func (s *unimplementedSubscription) Err() <-chan error {
+	ch := make(chan error, 1)
+	ch <- errors.New("Subscription type not implemented")
+	return ch
+}
+
+func (b *LesApiBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription {
+	return &unimplementedSubscription{}
+}


### PR DESCRIPTION
Extends API backend to subscribe to dropped txns, as well exposes feed over websocket subscription. Also adds an RPC transaction formatter.